### PR TITLE
NPE in FreemarkerConfigurationProducer.configuration() #67

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/freemarker/FreemarkerProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/freemarker/FreemarkerProcessor.java
@@ -122,7 +122,7 @@ public class FreemarkerProcessor {
     }
 
     @BuildStep
-    @Record(ExecutionTime.RUNTIME_INIT)
+    @Record(ExecutionTime.STATIC_INIT)
     void buildClients(
             FreemarkerRecorder recorder,
             BeanContainerBuildItem beanContainer,


### PR DESCRIPTION
@vsevel the idea is to move the `FreemarkerConfigurationProducer.initialize()` call from runtime init phase to static init phase. As far as I can see we can do that because all data passed to `FreemarkerConfigurationProducer.initialize()` is known at build time. I have I am not overseeing anything.

0.2.1 would be nice, although I am not sure we can wait more with Camel Quarkus release.