### PR TITLE
More maven fixes

### DIFF
--- a/integration-tests/config-defaults/pom.xml
+++ b/integration-tests/config-defaults/pom.xml
@@ -3,11 +3,11 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.quarkiverse.freemarker</groupId>
-        <artifactId>quarkiverse-freemarker-integration-tests</artifactId>
+        <artifactId>quarkus-freemarker-integration-tests</artifactId>
         <version>0.3.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>quarkiverse-freemarker-integration-tests-config-defaults</artifactId>
+    <artifactId>quarkus-freemarker-integration-tests-config-defaults</artifactId>
     <name>Quarkus - Freemarker - Integration Tests - Configuration defaults</name>
 
     <dependencies>

--- a/integration-tests/legacy-config/pom.xml
+++ b/integration-tests/legacy-config/pom.xml
@@ -3,11 +3,11 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.quarkiverse.freemarker</groupId>
-        <artifactId>quarkiverse-freemarker-integration-tests</artifactId>
+        <artifactId>quarkus-freemarker-integration-tests</artifactId>
         <version>0.3.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>quarkiverse-freemarker-integration-tests-legacy-config</artifactId>
+    <artifactId>quarkus-freemarker-integration-tests-legacy-config</artifactId>
     <name>Quarkus - Freemarker - Integration Tests - Legacy configuration</name>
 
     <dependencies>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -7,7 +7,7 @@
         <version>0.3.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>quarkiverse-freemarker-integration-tests</artifactId>
+    <artifactId>quarkus-freemarker-integration-tests</artifactId>
     <packaging>pom</packaging>
     <name>Quarkus - Freemarker - Integration Tests</name>
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -22,4 +22,21 @@
         <module>legacy-config</module>
         <module>template-sets</module>
     </modules>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <configuration>
+                            <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/integration-tests/template-sets/pom.xml
+++ b/integration-tests/template-sets/pom.xml
@@ -3,11 +3,11 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.quarkiverse.freemarker</groupId>
-        <artifactId>quarkiverse-freemarker-integration-tests</artifactId>
+        <artifactId>quarkus-freemarker-integration-tests</artifactId>
         <version>0.3.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>quarkiverse-freemarker-integration-tests-template-sets</artifactId>
+    <artifactId>quarkus-freemarker-integration-tests-template-sets</artifactId>
     <name>Quarkus - Freemarker - Integration Tests - Template sets</name>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
     <modules>
         <module>deployment</module>
         <module>runtime</module>
+        <module>integration-tests</module>
     </modules>
 
     <dependencyManagement>
@@ -62,18 +63,4 @@
             </plugins>
         </pluginManagement>
     </build>
-    <profiles>
-        <profile>
-            <id>it</id>
-            <activation>
-                <property>
-                    <name>performRelease</name>
-                    <value>!true</value>
-                </property>
-            </activation>
-            <modules>
-                <module>integration-tests</module>
-            </modules>
-        </profile>
-    </profiles>
 </project>


### PR DESCRIPTION
@vsevel the first commit is just clean up, the second should fix your release issue.

There are two things going on:
- we can't use a profile as apparently Quarkus bootstrap does not like it and ignore the module in the profile when resolving the workspace (I talked to Alexey about it) so for now, let's execute the ITs even when performing the release
- you used `maven.deploy.skip` to skip the deployment of the ITs but it's ineffective as we do not use the Maven deploy plugin in the release process: we use the Nexus plugin instead. I push a setup similar to what we do in Quarkus. It should work.