### PR TITLE
Remove staging exclusion for integration tests

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -22,21 +22,4 @@
         <module>legacy-config</module>
         <module>template-sets</module>
     </modules>
-
-    <profiles>
-        <profile>
-            <id>release</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <configuration>
-                            <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>


### PR DESCRIPTION
If the IT are not published, nothing gets published, since remote staging is done on the last project only, and the last project is one of the IT modules.
@aloubyansky also pointed out that they should be pushed anyway since quarkus-freemarker is part of the quarkus universe bom.
see this zulip [conversation](https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/quarkus-freemarker.20not.20pushed.20.20to.20remote.20registry)

/cc @gsmet 