### PR TITLE
Correct dead link on guides page

### DIFF
--- a/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -5,7 +5,7 @@ metadata:
   keywords:
     - "freemarker"
     - "template"
-  guide: "https://quarkus.io/guides/freemarker"
+  guide: "https://quarkiverse.github.io/quarkiverse-docs/quarkus-freemarker/dev/"
   categories:
     - "miscellaneous"
   status: "preview"


### PR DESCRIPTION
The guides link in the registry doesn't exist. I've updated to the best link I could find.